### PR TITLE
Fix spelling error

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -33,7 +33,7 @@ locals {
     service_account = "${var.service_account}"
   %{~endif~}
     image_pull_secrets = ${jsonencode(var.image_pull_secrets)}
-    priviledged     = ${var.build_job_priviledged}
+    privileged      = ${var.build_job_privileged}
     [runners.kubernetes.affinity]
     [runners.kubernetes.node_selector]
     %{~for key, value in var.build_job_node_selectors~}

--- a/variables.tf
+++ b/variables.tf
@@ -122,7 +122,7 @@ variable "build_job_run_container_as_user" {
   description = "SecurityContext: runAsUser for all running job pods"
 }
 
-variable "build_job_priviledged" {
+variable "build_job_privileged" {
   default     = false
   type        = bool
   description = "Run all containers with the privileged flag enabled. This will allow the docker:dind image to run if you need to run Docker"


### PR DESCRIPTION
This spelling error prevents the use of `privileged` containers.  When the runner registers itself with gitlab and renders this config template to the permanent config file location, the misspelled option is stripped from the output config.

Previously, the runner configs would have no value for `privileged` or `priviledged` regardless of the value of `var.build_job_priviledged`.  This change will cause the configs to contain `privileged = false` by default, and `privileged = true` when `var.build_job_privileged` is `true`.

Since this variable was broken before, I don't believe any backwards compatibility or variable deprecation warnings are necessary.