### PR TITLE
Runner config: Fix type "Shared" parameter string -> bool

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -8,7 +8,7 @@ locals {
   [runners.cache]
     Type = "${var.cache_type}"
     Path = "${var.cache_path}"
-    Shared = "${var.cache_shared}"
+    Shared = ${var.cache_shared}
     [runners.cache.s3]
     %{~for key, value in var.s3_cache_conf~}
       ${key} = ${value}


### PR DESCRIPTION
see more in https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnerscache-section

before this change runner can not merging configuration because `toml` parse error
```
FATAL: Could not handle configuration merging from template file error=couldn't load configuration template file: toml: cannot load TOML value of type string into a Go boolean
```