### PR TITLE
CI: change git:// to https:// in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.43.0
   hooks:
     - id: terraform_fmt


### PR DESCRIPTION
Working on a PR today, I'm getting bogged down by the `pre-commit` timing out repeatedly.  Really, `pre-commit` should use its locally-cached version, but it seems to want to check GitHub each time.

By switching to `https://` protocol on the plugin, this issue is gone and my commits are quick but can still run the `pre-commit` (ie no "-n" flag needed on the commit)

If this is OK, it also has the benefit of caching in caching-proxies a user may be using.  Might permit access in the aggressively-firewalled egress situation more popular a decade or two ago.