### PR TITLE
chore(deps): update pre-commit repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.43.0
+  rev: v1.76.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs


### PR DESCRIPTION
Update `pre-commit` resources to unblock development on unmodified non-linux.

As discussed with @MeNsaaH in https://github.com/DeimosCloud/terraform-kubernetes-gitlab-runner/pull/12, I found that the version of pre-commit was problematic on an unmodified MacOS dev system.  In looking further, the latest release doesn't have this problem, and seems to work OK.

Please consider this version-bump, literally a `pre-commit autoupdate`